### PR TITLE
Fixed GetAsync always returns empty list for sorted branches

### DIFF
--- a/src/StackExchange.Redis.Branch/Repository/RedisRepositoryBase.cs
+++ b/src/StackExchange.Redis.Branch/Repository/RedisRepositoryBase.cs
@@ -210,7 +210,7 @@ namespace StackExchange.Redis.Branch.Repository
 
             if (branch.IsSortable())
             {
-                return await GetSortedAsync(branch, double.MinValue, double.MaxValue, long.MinValue, long.MaxValue, groups);
+                return await GetSortedAsync(branch, double.MinValue, double.MaxValue, 0, long.MaxValue, groups);
             }
             else
             {
@@ -241,7 +241,7 @@ namespace StackExchange.Redis.Branch.Repository
 
             if (branch.IsSortable())
             {
-                return await GetSortedAsync(branch, from, double.MaxValue, long.MinValue, long.MaxValue, groups);
+                return await GetSortedAsync(branch, from, double.MaxValue, 0, long.MaxValue, groups);
             }
             else
             {
@@ -267,7 +267,7 @@ namespace StackExchange.Redis.Branch.Repository
 
             if (branch.IsSortable())
             {
-                return await GetSortedAsync(branch, from, to, long.MinValue, long.MaxValue, groups);
+                return await GetSortedAsync(branch, from, to, 0, long.MaxValue, groups);
             }
             else
             {


### PR DESCRIPTION
When calling private GetSortedAsync method, default value for skip is set to 0 from long.Min.

Resolves #10 