### PR TITLE
Make redisrepositorybase methods thread safe

### DIFF
--- a/src/StackExchange.Redis.Branch/Repository/RedisRepositoryBase.cs
+++ b/src/StackExchange.Redis.Branch/Repository/RedisRepositoryBase.cs
@@ -10,6 +10,10 @@ namespace StackExchange.Redis.Branch.Repository
     /// Base abstract class for redis repositories. Any overriden function must call base function. Otherwise unexpected behavior may be happened.
     /// </summary>
     /// <typeparam name="T"></typeparam>
+    /// <remarks>
+    ///     If any derived class from RedisRepositoryBase added to DI as Singleton, 
+    ///     making it thread-safe is the developer's responsibility.
+    /// </remarks> 
     public abstract class RedisRepositoryBase<T> : IRedisRepository<T> where T : RedisEntity, new()
     {
         public static string BRANCH_DATA = "BRANCH_DATA";
@@ -76,7 +80,7 @@ namespace StackExchange.Redis.Branch.Repository
         /// <param name="entity">Entity of repository</param>
         /// <param name="entityState">RedisEntityStateEnum</param>
         /// <returns></returns>
-        private async Task UpdateBranchesAsync(T entity, RedisEntityStateEnum entityState)
+        protected async Task UpdateBranchesAsync(T entity, RedisEntityStateEnum entityState)
         {
             switch (entityState)
             {

--- a/src/StackExchange.Redis.Branch/ServiceCollectionExtensions.cs
+++ b/src/StackExchange.Redis.Branch/ServiceCollectionExtensions.cs
@@ -23,9 +23,13 @@ namespace StackExchange.Redis.Branch
         }
 
         /// <summary>
-        /// Helper method to add redis repositories to DI as Singleton.
+        /// Helper method to add redis repositories to DI as Scoped.
         /// </summary>
         /// <param name="assemblies"></param>
+        /// <remarks>
+        ///     If any derived class from RedisRepositoryBase added to DI as Singleton, 
+        ///     making it thread-safe is the developer's responsibility.
+        /// </remarks> 
         private static void AddRedisBranches(this IServiceCollection services, params Assembly[] assemblies)
         {
             foreach (var assembly in assemblies)
@@ -42,7 +46,7 @@ namespace StackExchange.Redis.Branch
                         var iRepositoryType = typeof(IRedisRepository<>);
                         var iRepository = iRepositoryType.MakeGenericType(entityType);
 
-                        var serviceDescriptor = new ServiceDescriptor(iRepository, type, ServiceLifetime.Singleton);
+                        var serviceDescriptor = new ServiceDescriptor(iRepository, type, ServiceLifetime.Scoped);
                         services.Add(serviceDescriptor);
                     }
                 }

--- a/src/StackExchange.Redis.Branch/StackExchange.Redis.Branch.csproj
+++ b/src/StackExchange.Redis.Branch/StackExchange.Redis.Branch.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Doğa Barış Çakmak</Authors>
     <Description>Lightweight library to query Redis by predefined queries on top of StackExchange.Redis.
 This library enables that you can use redis database with predefined queries. Queries are seen like pipelines which are executed when data is writing/removing on redis.</Description>
@@ -15,9 +15,7 @@ This library enables that you can use redis database with predefined queries. Qu
     <RepositoryType>Git</RepositoryType>
     <PackageTags>Redis,StackExchange.Redis,Query,Pipeline,Predefine Query</PackageTags>
     <PackageIcon>logo.png</PackageIcon>
-    <PackageReleaseNotes>- Integration tests extended.
-- Fixed GetAsync always returns empty list for sorted branches.
-- Fixed after UpdateAsync, entity not deleted from old branches.</PackageReleaseNotes>
+    <PackageReleaseNotes>- Fixed mixing threads issue for UpdateBranches</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/tests/StackExchange.Redis.Branch.IntegrationTest/Helpers/RedisFixture.cs
+++ b/src/tests/StackExchange.Redis.Branch.IntegrationTest/Helpers/RedisFixture.cs
@@ -34,18 +34,17 @@ namespace StackExchange.Redis.Branch.IntegrationTest.Helpers
 
             TestSettings = new TestSettings()
             {
-                IsDockerComposeRequired = Convert.ToBoolean(config.GetSection(TestSettings.Position)["IsDockerComposeRequired"]),
                 RedisConnectionConfiguration = config.GetSection(TestSettings.Position)["RedisConnectionConfiguration"],
-                RedisDockerComposeFile = config.GetSection(TestSettings.Position)["RedisDockerComposeFile"],
-                RedisDockerWorkingDir = config.GetSection(TestSettings.Position)["RedisDockerWorkingDir"],
+                DockerComposeFile = config.GetSection(TestSettings.Position)["DockerComposeFile"],
+                DockerWorkingDir = config.GetSection(TestSettings.Position)["DockerWorkingDir"],
                 DockerComposeExePath = config.GetSection(TestSettings.Position)["DockerComposeExePath"],
                 TestDataFilePath = config.GetSection(TestSettings.Position)["TestDataFilePath"],
                 IsGithubAction = IsGithubAction
             };
 
-            if (TestSettings.IsDockerComposeRequired && !TestSettings.IsGithubAction)
+            if (!TestSettings.IsGithubAction)
             {
-                dockerStarter = new DockerStarter(TestSettings.DockerComposeExePath, TestSettings.RedisDockerComposeFile, TestSettings.RedisDockerWorkingDir);
+                dockerStarter = new DockerStarter(TestSettings.DockerComposeExePath, TestSettings.DockerComposeFile, TestSettings.DockerWorkingDir);
                 dockerStarter.Start();
             }
 
@@ -92,7 +91,7 @@ namespace StackExchange.Redis.Branch.IntegrationTest.Helpers
                 if (disposing)
                 {
                     DI.Dispose();
-                    if (TestSettings.IsDockerComposeRequired && !TestSettings.IsGithubAction)
+                    if (!TestSettings.IsGithubAction)
                     {
                         dockerStarter.Dispose();
                     }

--- a/src/tests/StackExchange.Redis.Branch.IntegrationTest/Helpers/TestSettings.cs
+++ b/src/tests/StackExchange.Redis.Branch.IntegrationTest/Helpers/TestSettings.cs
@@ -9,10 +9,9 @@ namespace StackExchange.Redis.Branch.IntegrationTest.Helpers
     public class TestSettings
     {
         public const string Position = "TestSettings";
-        public bool IsDockerComposeRequired { get; set; }
         public string RedisConnectionConfiguration { get; set; }
-        public string RedisDockerComposeFile { get; set; }
-        public string RedisDockerWorkingDir { get; set; }
+        public string DockerComposeFile { get; set; }
+        public string DockerWorkingDir { get; set; }
         public string DockerComposeExePath { get; set; }
         public string TestDataFilePath { get; set; }
         public bool IsGithubAction { get; set; }

--- a/src/tests/StackExchange.Redis.Branch.IntegrationTest/testsettings.json
+++ b/src/tests/StackExchange.Redis.Branch.IntegrationTest/testsettings.json
@@ -3,6 +3,8 @@
     "IsDockerComposeRequired": true,
     "RedisConnectionConfiguration": "localhost:6379,allowAdmin=true",
     "DockerComposeExePath": "C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker-compose.exe",
+    "DockerWorkingDir": "D:\\OpenSourceProjects\\StackExchange.Redis.Branch\\src\\tests\\StackExchange.Redis.Branch.IntegrationTest",
+    "DockerComposeFile": "D:\\OpenSourceProjects\\StackExchange.Redis.Branch\\src\\tests\\StackExchange.Redis.Branch.IntegrationTest\\dockercompose-integrationtest.yml",
     "TestDataFilePath": "testdata.json"
   }
 }


### PR DESCRIPTION
Resolves #23 

To resolve the multi-thread issue for the Redis repository class, the classes inherited by RedisRepositoryBase are injecting as scoped to DI. Before that, they were injecting as a singleton and it was causing a mixing threading issue for the UpdateBranches method. The developers want to inject  Redis Repository classes as a singleton, must take care of the threading issues. They can be easily solved by wrapping overriding RedisRepositoryBase methods and wrapping UpdateBranches method with the lock keyword.